### PR TITLE
Use call_user_func for Backwards Compatibility

### DIFF
--- a/src/TransientFaultHandler.php
+++ b/src/TransientFaultHandler.php
@@ -81,7 +81,7 @@ class TransientFaultHandler implements TransientFaultHandlerInterface
             $exception = null;
 
             try {
-                $returnValue = $task();
+                $returnValue = call_user_func($task);
                 $transient = $this->returnValueDetectionStrategy->isReturnValueTransient($returnValue);
 
                 // If the result does not indicate a transient error, return to the user

--- a/tests/src/Samples.php
+++ b/tests/src/Samples.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of graze/transient-fault-handler.
+ *
+ * Copyright (c) 2017 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/transient-fault-handler/blob/master/LICENSE.md
+ * @link https://github.com/graze/transient-fault-handler
+ */
+
+namespace Graze\TransientFaultHandler\Test;
+
+/**
+ * This class contains sample tasks that can be used by test.
+ */
+class Samples
+{
+    /**
+     * @return string
+     */
+    public static function simpleTask()
+    {
+        return 'success';
+    }
+}

--- a/tests/unit/TransientFaultHandlerTest.php
+++ b/tests/unit/TransientFaultHandlerTest.php
@@ -46,6 +46,32 @@ class TransientFaultHandlerTest extends TestCase
     }
 
     /**
+     * Test that a task can be passed as a string holding the namespaced name of a function.
+     *
+     * A string containing the namespace and name of a function is a "Callable" in PHP. Before PHP 7, calling a string
+     * like this using bracket notation would fail, e.g. '\Foo::test'(), and so call_user_func() had to be used. This
+     * test protects against this backwards compatibility being removed.
+     */
+    public function testCallablesPassedAsStringAreExecuted()
+    {
+        // Mock the detection strategy
+        $this->returnValueDetectionStrategy->shouldReceive('isReturnValueTransient')->andReturn(false)->once();
+
+        // Create a handler
+        $handler = new TransientFaultHandler(
+            $this->exceptionDetectionStrategy,
+            $this->returnValueDetectionStrategy,
+            $this->retryStrategy,
+            $this->sleep
+        );
+
+        $result = $handler->execute('\Graze\TransientFaultHandler\Test\Samples::simpleTask');
+
+        // Test that the result of the task is returned by the handler
+        $this->assertEquals('success', $result);
+    }
+
+    /**
      * Test that retries stop after the task returns a success value.
      *
      * @dataProvider doesNotRetryAfterSuccessDataProvider


### PR DESCRIPTION
A string containing the namespace and name of a function is a "Callable" in PHP. Before PHP 7, calling a string like this using bracket notation would fail, e.g. `'\Foo::test'()`, therefore `call_user_func` is a more robust way to call the task.

A test has been added that fails without this change in <= PHP 5.6.